### PR TITLE
Redmine 5

### DIFF
--- a/redmine_wiki_page_tree/assets/javascripts/sidebar__page-tree.js
+++ b/redmine_wiki_page_tree/assets/javascripts/sidebar__page-tree.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .forEach(a => {
       // ドッラグ開始時にドラッグ中要素の情報を記録
       a.addEventListener('dragstart', (e) => {
-        e.dataTransfer.setData('url', e.target.getAttribute('href'))
+        e.dataTransfer.setData('text/plain', e.target.getAttribute('href'))
       })
       // ドラッグオーバー時にドロップ可能表示
       a.addEventListener('dragover', (e) => {
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Prevent redirection to the URL like `file://` on the Firefox.
         e.preventDefault()
 
-        const url = e.dataTransfer.getData('url') // 移動するwikiページのURL
+        const url = e.dataTransfer.getData('text/plain') // 移動するwikiページのURL
         const parentId = e.target.getAttribute('data-wiki-page-id') // 親ページのID
 
         // CSRF対策用トークン

--- a/redmine_wiki_page_tree/init.rb
+++ b/redmine_wiki_page_tree/init.rb
@@ -4,7 +4,7 @@ Redmine::Plugin.register :redmine_wiki_page_tree do
   name 'Redmine Wiki Page Tree Plugin'
   author 'Shigeru Nakajima'
   description 'Redmine plugin to show the page tree view at the sidebar.'
-  version '0.0.2'
+  version '0.0.3'
   url 'https://github.com/ledsun/redmine_wiki_page_tree'
   author_url 'https://github.com/ledsun'
 end

--- a/redmine_wiki_page_tree/init.rb
+++ b/redmine_wiki_page_tree/init.rb
@@ -1,4 +1,4 @@
-require_dependency 'redmine_wiki_page_tree_hook_listener'
+require_dependency File.expand_path('./lib/redmine_wiki_page_tree_hook_listener', __dir__)
 
 Redmine::Plugin.register :redmine_wiki_page_tree do
   name 'Redmine Wiki Page Tree Plugin'

--- a/redmine_wiki_page_tree/lib/redmine_wiki_page_tree_hook_listener.rb
+++ b/redmine_wiki_page_tree/lib/redmine_wiki_page_tree_hook_listener.rb
@@ -1,4 +1,4 @@
-class RedmineWikiPageTreesHookListener < Redmine::Hook::ViewListener
+class RedmineWikiPageTreeHookListener < Redmine::Hook::ViewListener
   include ActionView::Helpers::DateHelper
   include ActionView::Context
 


### PR DESCRIPTION
Corresponds to the change in the Rails class loader to zeitwerk starting with Redmine 5.
It also fixes an issue where the format specified during drag-and-drop was not strict.

fix #3